### PR TITLE
Add minimal landing page

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -3,18 +3,33 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to TopoToolbox's documentation!
-=======================================
+TopoToolbox
+===========
+
+TopoToolbox is an open-source software suite for the analysis of
+digital elevation models.
+
+Version 3 of TopoToolbox has been redesigned around a C library,
+`libtopotoolbox <https//topotoolbox.github.io/libtopotoolbox>`_ that
+implements fundamental algorithms for topographic analysis.
+
+Bindings for libtopotoolbox in higher-level languages provide a
+user-friendly interface to the library and enable data important and
+export, visualization and interaction with the geospatial data
+analysis ecosystems of those languages.
+
+Bindings are currently under development for
+
+* `MATLAB <https://github.com/TopoToolbox/topotoolbox>`_
+* `Python <https://topotoolbox.github.io/pytopotoolbox>`_
+* `R <https://github.com/TopoToolbox/topotoolboxr>`_
+
+Development of TopoToolbox is managed through the `TopoToolbox
+organization <https://github.com/TopoToolbox>`_ on GitHub.
+
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
 
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
Closes #1

This minimal landing page contains links to the various subprojects for TopoToolbox v3.